### PR TITLE
Added workaround for GCC9 or eariler

### DIFF
--- a/flat_map/__config.hpp
+++ b/flat_map/__config.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Kohei Takahashi
+// This software is released under the MIT License, see LICENSE.
+
+#pragma once
+
+#define FLAT_MAP_COMPILER_VERSION(major, minor, patch) (((major * 1000) + minor) * 100 + patch)
+
+#if defined(__GNUC__) && !defined(__clang__)
+#   define FLAT_MAP_COMPILER_GCC FLAT_MAP_COMPILER_VERSION(__GNUC__, __GNU_MINOR__, __GNU_PATCHLEVEL__)
+#else
+#   define FLAT_MAP_COMPILER_GCC 0
+#endif

--- a/flat_map/flat_map.hpp
+++ b/flat_map/flat_map.hpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "flat_map/__fwd.hpp"
+#include "flat_map/__config.hpp"
 #include "flat_map/__flat_tree.hpp"
 
 namespace flat_map
@@ -120,7 +121,15 @@ public:
 
     flat_map& operator=(flat_map const& other) = default;
 
-    flat_map& operator=(flat_map&& other) noexcept(std::is_nothrow_move_assignable_v<_super>) = default;
+    flat_map& operator=(flat_map&& other) noexcept(std::is_nothrow_move_assignable_v<_super>)
+#if FLAT_MAP_COMPILER_VERSION(10,0,0) <= FLAT_MAP_COMPILER_GCC
+      = default;
+#else
+    {
+        _super::operator=(std::move(other));
+        return *this;
+    }
+#endif
 
     flat_map& operator=(std::initializer_list<value_type> ilist)
     {


### PR DESCRIPTION
Compiler generated move assignment won't move
