### PR TITLE
Fix the include paths for catch2 and benchmark.

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(cmake/benchmark)
+include(${PROJECT_SOURCE_DIR}/cmake/benchmark.cmake)
 
 add_custom_target(benchmark)
 set_target_properties(benchmark PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(requirements INTERFACE -Werror=return-type -Werror=undefined-inline)
 endif()
 
-include(cmake/catch2)
+include(${PROJECT_SOURCE_DIR}/cmake/catch2.cmake)
 
 add_custom_target(unit_test)
 set_target_properties(unit_test PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)


### PR DESCRIPTION
Hello,

When I used this project by `add_subdirectory`, I met a problem that the include paths for catch2 and benchmark are not found. Since I fixed them, could you please merge this PR?