### PR TITLE
Forward allocators as allocator_type

### DIFF
--- a/docs/tied_sequence.md
+++ b/docs/tied_sequence.md
@@ -595,7 +595,7 @@ constexpr typename tied_sequence<Sequences...>::size_type erase_if(tied_sequence
 
 Erase every elements which `pred` returned true.
 
-### forward\_allocator
+### forward_allocator
 
 ```cpp
 template <typename... Allocators>

--- a/docs/tied_sequence.md
+++ b/docs/tied_sequence.md
@@ -49,7 +49,6 @@ using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 ```cpp
 constexpr tied_sequence();
-constexpr explicit tied_sequence(allocator_type const&);
 ```
 
 **Exceptions**
@@ -58,6 +57,7 @@ No exception only if for all sequences meet all of
 - `std::is_nothrow_default_constructible_v<Sequence> == true`
 
 ```cpp
+constexpr explicit tied_sequence(allocator_type const& alloc) noexcept;
 constexpr explicit tied_sequence(typename Sequences::allocator_type const&... alloc) noexcept;
 ```
 
@@ -65,10 +65,10 @@ Construct sequences form corresponding allocator.
 
 ```cpp
 constexpr tied_sequence(size_type count, value_type const& value);
-constexpr tied_sequence(size_type count, value_type const& value, allocator_type const&);
+constexpr tied_sequence(size_type count, value_type const& value, allocator_type const& alloc);
 constexpr tied_sequence(size_type count, value_type const& value, typename Sequences::allocator_type const&... alloc);
 constexpr tied_sequence(size_type count);
-constexpr tied_sequence(size_type count, allocator_type const&);
+constexpr tied_sequence(size_type count, allocator_type const& alloc);
 constexpr tied_sequence(size_type count, typename Sequences::allocator_type const&... alloc);
 ```
 
@@ -79,7 +79,7 @@ template <typename InputIterator>
 constexpr tied_sequence(InputIterator first, InputIterator last);
 
 template <typename InputIterator>
-constexpr tied_sequence(InputIterator first, InputIterator last, allocator_type const&);
+constexpr tied_sequence(InputIterator first, InputIterator last, allocator_type const& alloc);
 
 template <typename InputIterator>
 constexpr tied_sequence(InputIterator first, InputIterator last, typename Sequences::allocator_type const&... alloc);
@@ -94,7 +94,7 @@ Construct containers from `[first, last)`.
 
 ```cpp
 constexpr tied_sequence(tied_sequence const& other);
-constexpr tied_sequence(tied_sequence const& other, allocator_type const&);
+constexpr tied_sequence(tied_sequence const& other, allocator_type const& alloc);
 constexpr tied_sequence(tied_sequence const& other, typename Sequences::allocator_type const&... alloc);
 ```
 
@@ -102,7 +102,7 @@ Copy from other.
 
 ```cpp
 constexpr tied_sequence(tied_sequence&& other);
-constexpr tied_sequence(tied_sequence&& other, allocator_type const&);
+constexpr tied_sequence(tied_sequence&& other, allocator_type const& alloc);
 constexpr tied_sequence(tied_sequence&& other, typename Sequences::allocator_type const&... alloc);
 ```
 
@@ -111,7 +111,7 @@ Move entire elements from other.
 
 ```cpp
 constexpr tied_sequence(std::initializer_list<value_type> init);
-constexpr tied_sequence(std::initializer_list<value_type> init, allocator_type const&);
+constexpr tied_sequence(std::initializer_list<value_type> init, allocator_type const& alloc);
 constexpr tied_sequence(std::initializer_list<value_type> init, typename Sequences::allocator_type const&... alloc);
 ```
 
@@ -594,3 +594,12 @@ constexpr typename tied_sequence<Sequences...>::size_type erase_if(tied_sequence
 ```
 
 Erase every elements which `pred` returned true.
+
+### forward\_allocator
+
+```cpp
+template <typename... Allocators>
+/* unspecified */ forward_allocator(Allocators&&... alloc);
+```
+
+Forward allocators as `tied_sequence::allocator_type`.

--- a/flat_map/__memory.hpp
+++ b/flat_map/__memory.hpp
@@ -1,20 +1,33 @@
-// Copyright (c) 2021 Kohei Takahashi
+// Copyright (c) 2021,2024 Kohei Takahashi
 // This software is released under the MIT License, see LICENSE.
 
 #pragma once
 
 #include <memory>
 #include <new>
+#include <tuple>
 
-namespace flat_map::detail
+namespace flat_map
 {
 
-struct fake_allocator
+namespace detail
 {
-    template <typename>
-    struct rebind { using other = fake_allocator; };
+
+template <typename AllocatorTuple>
+struct fake_allocator : private AllocatorTuple
+{
+    template <typename U>
+    struct rebind { using other = fake_allocator<U>; };
 
     using value_type = void;
+
+    fake_allocator() noexcept = default;
+
+    explicit fake_allocator(AllocatorTuple&& tuple)      noexcept : AllocatorTuple{std::move(tuple)} { }
+    explicit fake_allocator(AllocatorTuple const& tuple) noexcept : AllocatorTuple{tuple} { }
+
+    template <std::size_t I> decltype(auto) get()       noexcept { return std::get<I>(static_cast<AllocatorTuple&>(*this)); }
+    template <std::size_t I> decltype(auto) get() const noexcept { return std::get<I>(static_cast<AllocatorTuple&>(*this)); }
 
     [[noreturn]]
     void* allocate(std::size_t) { throw std::bad_alloc(); }
@@ -25,3 +38,11 @@ struct fake_allocator
 };
 
 } // namespace flat_map::detail
+
+template <typename... Allocators>
+auto forward_allocator(Allocators&&... alloc)
+{
+    return detail::fake_allocator{std::tuple<Allocators...>(std::forward<Allocators>(alloc)...)};
+}
+
+} // namespace flat_map

--- a/flat_map/__memory.hpp
+++ b/flat_map/__memory.hpp
@@ -26,6 +26,9 @@ struct fake_allocator : private AllocatorTuple
     explicit fake_allocator(AllocatorTuple&& tuple)      noexcept : AllocatorTuple{std::move(tuple)} { }
     explicit fake_allocator(AllocatorTuple const& tuple) noexcept : AllocatorTuple{tuple} { }
 
+    template <typename... Allocators>
+    explicit fake_allocator(std::allocator_arg_t, Allocators&&... allocs) noexcept : AllocatorTuple{std::forward<Allocators>(allocs)...} { }
+
     template <std::size_t I> decltype(auto) get()       noexcept { return std::get<I>(static_cast<AllocatorTuple&>(*this)); }
     template <std::size_t I> decltype(auto) get() const noexcept { return std::get<I>(static_cast<AllocatorTuple&>(*this)); }
 

--- a/flat_map/__memory.hpp
+++ b/flat_map/__memory.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <new>
 #include <tuple>
+#include <type_traits>
 
 namespace flat_map
 {
@@ -21,18 +22,19 @@ struct fake_allocator : private AllocatorTuple
 
     using value_type = void;
 
-    fake_allocator() noexcept = default;
-    fake_allocator(fake_allocator const&) = default;
-    fake_allocator(fake_allocator&&) = default;
+    fake_allocator() noexcept(std::is_nothrow_default_constructible_v<AllocatorTuple>) = default;
 
-    explicit fake_allocator(AllocatorTuple const& tuple) noexcept : AllocatorTuple{tuple} { }
-    explicit fake_allocator(AllocatorTuple&& tuple)      noexcept : AllocatorTuple{std::move(tuple)} { }
+    fake_allocator(fake_allocator const&) noexcept(std::is_nothrow_copy_constructible_v<AllocatorTuple>) = default;
+    fake_allocator(fake_allocator&&)      noexcept(std::is_nothrow_move_constructible_v<AllocatorTuple>) = default;
+
+    explicit fake_allocator(AllocatorTuple const& tuple) noexcept(std::is_nothrow_copy_constructible_v<AllocatorTuple>) : AllocatorTuple{tuple} { }
+    explicit fake_allocator(AllocatorTuple&& tuple)      noexcept(std::is_nothrow_move_constructible_v<AllocatorTuple>) : AllocatorTuple{std::move(tuple)} { }
 
     template <typename... Allocators>
     explicit fake_allocator(std::allocator_arg_t, Allocators&&... allocs) noexcept : AllocatorTuple{std::forward<Allocators>(allocs)...} { }
 
-    fake_allocator& operator=(fake_allocator const&) noexcept = default;
-    fake_allocator& operator=(fake_allocator&&) noexcept = default;
+    fake_allocator& operator=(fake_allocator const&) noexcept(std::is_nothrow_copy_assignable_v<AllocatorTuple>) = default;
+    fake_allocator& operator=(fake_allocator&&)      noexcept(std::is_nothrow_move_assignable_v<AllocatorTuple>) = default;
 
     template <std::size_t I> decltype(auto) get()       noexcept { return std::get<I>(static_cast<AllocatorTuple&>(*this)); }
     template <std::size_t I> decltype(auto) get() const noexcept { return std::get<I>(static_cast<AllocatorTuple const&>(*this)); }
@@ -41,14 +43,14 @@ struct fake_allocator : private AllocatorTuple
     void* allocate(std::size_t) { throw std::bad_alloc(); }
     constexpr void deallocate(void*, std::size_t) { }
 
-    constexpr bool operator==(fake_allocator) const { return true; }
-    constexpr bool operator!=(fake_allocator) const { return false; }
+    constexpr bool operator==(fake_allocator const& other) const noexcept { return static_cast<AllocatorTuple const&>(*this) == static_cast<AllocatorTuple const&>(other); }
+    constexpr bool operator!=(fake_allocator const& other) const noexcept { return !operator==(other); }
 };
 
 } // namespace flat_map::detail
 
 template <typename... Allocators>
-auto forward_allocator(Allocators&&... alloc)
+auto forward_allocator(Allocators&&... alloc) noexcept
 {
     return detail::fake_allocator<std::tuple<Allocators...>>{std::allocator_arg, std::forward<Allocators>(alloc)...};
 }

--- a/flat_map/tied_sequence.hpp
+++ b/flat_map/tied_sequence.hpp
@@ -419,7 +419,10 @@ public:
 
     constexpr void assign(std::initializer_list<value_type> ilist) { *this = ilist; }
 
-    constexpr allocator_type get_allocator() const noexcept { return {}; }
+    constexpr allocator_type get_allocator() const noexcept
+    {
+        return std::apply([](auto&... seqs) { return allocator_type{std::allocator_arg, seqs.get_allocator()...}; }, _seq);
+    }
 
     constexpr reference at(size_type pos)
     {

--- a/flat_map/tied_sequence.hpp
+++ b/flat_map/tied_sequence.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021,2023 Kohei Takahashi
+// Copyright (c) 2021,2023-2024 Kohei Takahashi
 // This software is released under the MIT License, see LICENSE.
 
 #pragma once
@@ -282,7 +282,7 @@ class tied_sequence
 
 public:
     using value_type = std::tuple<typename Sequences::value_type...>;
-    using allocator_type = detail::fake_allocator;
+    using allocator_type = detail::fake_allocator<std::tuple<typename Sequences::allocator_type...>>;
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
     using reference = std::tuple<typename Sequences::reference...>;

--- a/flat_map/tied_sequence.hpp
+++ b/flat_map/tied_sequence.hpp
@@ -295,6 +295,22 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 private:
+    template <std::size_t... N>
+    constexpr tied_sequence(std::index_sequence<N...>, allocator_type const& alloc)
+      : _seq{alloc.template get<N>()...} { }
+
+    template <std::size_t... N>
+    constexpr tied_sequence(std::index_sequence<N...>, size_type count, allocator_type const& alloc)
+      : _seq{Sequences(count, alloc.template get<N>())...} { }
+
+    template <std::size_t... N, typename T>
+    constexpr tied_sequence(std::index_sequence<N...>, size_type count, T&& value, allocator_type const& alloc)
+      : _seq{Sequences(count, std::get<N>(std::forward<T>(value)), alloc.template get<N>())...} { }
+
+    template <std::size_t... N, typename T>
+    constexpr tied_sequence(std::index_sequence<N...>, T&& value, allocator_type const& alloc)
+      : _seq{Sequences(std::get<N>(std::forward<T>(value)), alloc.template get<N>())...} { }
+
     template <std::size_t... N, typename T>
     constexpr tied_sequence(std::index_sequence<N...>, size_type count, T&& value, typename Sequences::allocator_type const&... alloc)
       : _seq{Sequences(count, std::get<N>(std::forward<T>(value)), alloc)...} { }
@@ -302,6 +318,10 @@ private:
     template <std::size_t... N, typename T>
     constexpr tied_sequence(std::index_sequence<N...>, T&& value, typename Sequences::allocator_type const&... alloc)
       : _seq{Sequences(std::get<N>(std::forward<T>(value)), alloc)...} { }
+
+    template <typename InputIterator, std::size_t... N>
+    constexpr tied_sequence(std::index_sequence<N...> indices, InputIterator first, InputIterator last, allocator_type const& alloc)
+      : tied_sequence{indices, typename std::iterator_traits<InputIterator>::iterator_category{}, first, last, alloc.template get<N>()...} { }
 
     template <typename InputIterator, std::size_t... N>
     constexpr tied_sequence(std::index_sequence<N...>, std::input_iterator_tag, InputIterator, InputIterator, typename Sequences::allocator_type const&...)
@@ -314,6 +334,10 @@ private:
     constexpr tied_sequence(std::index_sequence<N...>, std::forward_iterator_tag, ForwardIterator first, ForwardIterator last, typename Sequences::allocator_type const&... alloc)
       : _seq{Sequences(detail::unzip<N>(first), detail::unzip<N>(last), alloc)...} { }
 
+    template <std::size_t... N>
+    constexpr tied_sequence(std::index_sequence<N...>, std::initializer_list<value_type> init, allocator_type const& alloc)
+      : tied_sequence{init, alloc.template get<N>()...} { }
+
 public:
     constexpr tied_sequence() noexcept((std::is_nothrow_default_constructible_v<Sequences> && ...))
 #if FLAT_MAP_WORKAROUND(FLAT_MAP_COMPILER_GCC, < FLAT_MAP_COMPILER_VERSION(10,0,0))
@@ -322,22 +346,24 @@ public:
       = default;
 #endif
 
-    constexpr explicit tied_sequence(allocator_type const&) noexcept(std::is_nothrow_default_constructible_v<tied_sequence>) : tied_sequence() { }
+    constexpr explicit tied_sequence(allocator_type const& alloc) noexcept
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, alloc) { }
 
     constexpr explicit tied_sequence(typename Sequences::allocator_type const&... alloc) noexcept : _seq{alloc...} { }
 
     constexpr tied_sequence(size_type count, value_type const& value)
       : tied_sequence(count, value, typename Sequences::allocator_type{}...) { }
 
-    constexpr tied_sequence(size_type count, value_type const& value, allocator_type const&)
-      : tied_sequence(count, value) { }
+    constexpr tied_sequence(size_type count, value_type const& value, allocator_type const& alloc)
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, count, value, alloc) { }
 
     constexpr tied_sequence(size_type count, value_type const& value, typename Sequences::allocator_type const&... alloc)
       : tied_sequence(std::index_sequence_for<Sequences...>{}, count, value, alloc...) { }
 
     constexpr tied_sequence(size_type count) : tied_sequence(count, typename Sequences::allocator_type{}...) { }
 
-    constexpr tied_sequence(size_type count, allocator_type const&) : tied_sequence(count) { }
+    constexpr tied_sequence(size_type count, allocator_type const& alloc)
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, count, alloc) { }
 
     constexpr tied_sequence(size_type count, typename Sequences::allocator_type const&... alloc)
       : _seq{Sequences(count, alloc)...} { }
@@ -347,7 +373,8 @@ public:
       : tied_sequence(first, last, typename Sequences::allocator_type{}...) { }
 
     template <typename InputIterator>
-    constexpr tied_sequence(InputIterator first, InputIterator last, allocator_type const&) : tied_sequence(first, last) { }
+    constexpr tied_sequence(InputIterator first, InputIterator last, allocator_type const& alloc)
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, first, last, alloc) { }
 
     template <typename InputIterator>
     constexpr tied_sequence(InputIterator first, InputIterator last, typename Sequences::allocator_type const&... alloc)
@@ -355,22 +382,25 @@ public:
 
     constexpr tied_sequence(tied_sequence const&) = default;
 
-    constexpr tied_sequence(tied_sequence const& other, allocator_type const&) : tied_sequence(other) { }
+    constexpr tied_sequence(tied_sequence const& other, allocator_type const& alloc)
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, other._seq, alloc) { }
 
     constexpr tied_sequence(tied_sequence const& other, typename Sequences::allocator_type const&... alloc)
-      : tied_sequence(std::index_sequence_for<Sequences...>{}, other, alloc...) { }
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, other._seq, alloc...) { }
 
     constexpr tied_sequence(tied_sequence&&) noexcept = default;
 
-    constexpr tied_sequence(tied_sequence&& other, allocator_type const&) : tied_sequence(std::move(other)) { }
+    constexpr tied_sequence(tied_sequence&& other, allocator_type const& alloc)
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, std::move(other._seq), alloc) { }
 
     constexpr tied_sequence(tied_sequence&& other, typename Sequences::allocator_type const&... alloc)
-      : tied_sequence(std::index_sequence_for<Sequences...>{}, std::move(other), alloc...) { }
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, std::move(other._seq), alloc...) { }
 
     constexpr tied_sequence(std::initializer_list<value_type> init)
       : tied_sequence(init, typename Sequences::allocator_type{}...) { }
 
-    constexpr tied_sequence(std::initializer_list<value_type> init, allocator_type const&) : tied_sequence(init) { }
+    constexpr tied_sequence(std::initializer_list<value_type> init, allocator_type const& alloc)
+      : tied_sequence(std::index_sequence_for<Sequences...>{}, init, alloc) { }
 
     constexpr tied_sequence(std::initializer_list<value_type> init, typename Sequences::allocator_type const&... alloc)
       : tied_sequence(init.begin(), init.end(), alloc...) { }

--- a/test/test_case/deduction_guide.ipp
+++ b/test/test_case/deduction_guide.ipp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021,2023 Kohei Takahashi
+// Copyright (c) 2021,2023-2024 Kohei Takahashi
 // This software is released under the MIT License, see LICENSE.
 
 #include <catch2/catch_test_macros.hpp>
@@ -7,18 +7,7 @@
 #include <functional>
 
 #include "config.hpp"
-
-template <typename T>
-struct stateful_allocator : public std::allocator<T>
-{
-    std::string state;
-
-    // Hide std::allocator::rebind for C++17 mode.
-    template <typename U>
-    struct rebind { using other = stateful_allocator<U>; };
-
-    stateful_allocator(char const* state) : state{state} {};
-};
+#include "memory.hpp"
 
 TEST_CASE("deduction guide", "[deduction guide]")
 {

--- a/test/test_case/memory.hpp
+++ b/test/test_case/memory.hpp
@@ -19,6 +19,9 @@ struct stateful_allocator : public std::allocator<T>
     stateful_allocator(stateful_allocator const&) noexcept = default;
     stateful_allocator(stateful_allocator&&) noexcept = default;
 
+    stateful_allocator& operator=(stateful_allocator const&) noexcept = default;
+    stateful_allocator& operator=(stateful_allocator&&) noexcept = default;
+
     template <typename U>
     stateful_allocator(stateful_allocator<U> const& other) noexcept : state{other.state} { }
 

--- a/test/test_case/memory.hpp
+++ b/test/test_case/memory.hpp
@@ -12,6 +12,8 @@ struct stateful_allocator : public std::allocator<T>
     template <typename U>
     struct rebind { using other = stateful_allocator<U>; };
 
+    stateful_allocator() : state{"unspecified state"} {}
+
     stateful_allocator(char const* state) : state{state} {}
 
     stateful_allocator(stateful_allocator const&) noexcept = default;

--- a/test/test_case/memory.hpp
+++ b/test/test_case/memory.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Kohei Takahashi
+// This software is released under the MIT License, see LICENSE.
+
+#pragma once
+
+template <typename T>
+struct stateful_allocator : public std::allocator<T>
+{
+    std::string state;
+
+    // Hide std::allocator::rebind for C++17 mode.
+    template <typename U>
+    struct rebind { using other = stateful_allocator<U>; };
+
+    stateful_allocator(char const* state) : state{state} {}
+
+    stateful_allocator(stateful_allocator const&) noexcept = default;
+    stateful_allocator(stateful_allocator&&) noexcept = default;
+
+    template <typename U>
+    stateful_allocator(stateful_allocator<U> const& other) noexcept : state{other.state} { }
+
+    template <typename U>
+    stateful_allocator(stateful_allocator<U>&& other) noexcept : state{std::move(other.state)} { }
+};

--- a/test/tied_sequence.cpp
+++ b/test/tied_sequence.cpp
@@ -1097,6 +1097,10 @@ TEST_CASE("allocator", "[allocator]")
             stateful_allocator<int>{"state1"},
             stateful_allocator<int>{"state2"}
         };
+
+        auto alloc = ts.get_allocator();
+        REQUIRE(alloc.get<0>().state == "state1");
+        REQUIRE(alloc.get<1>().state == "state2");
     }
 
     SECTION("allocator forwarding")

--- a/test/tied_sequence.cpp
+++ b/test/tied_sequence.cpp
@@ -1098,4 +1098,28 @@ TEST_CASE("allocator", "[allocator]")
             stateful_allocator<int>{"state2"}
         };
     }
+
+    SECTION("allocator forwarding")
+    {
+        [[maybe_unused]] flat_map::tied_sequence<std::vector<int, stateful_allocator<int>>, std::deque<int, stateful_allocator<int>>> ts
+        {
+            flat_map::forward_allocator(
+                stateful_allocator<int>{"state1"},
+                stateful_allocator<int>{"state2"}
+            )
+        };
+    }
+
+    SECTION("nested")
+    {
+        [[maybe_unused]] flat_map::tied_sequence<flat_map::tied_sequence<std::vector<int, stateful_allocator<int>>, std::deque<int, stateful_allocator<int>>>> nts
+        {
+            flat_map::forward_allocator(
+                flat_map::forward_allocator(
+                    stateful_allocator<int>{"state1"},
+                    stateful_allocator<int>{"state2"}
+                )
+            )
+        };
+    }
 }

--- a/test/tied_sequence.cpp
+++ b/test/tied_sequence.cpp
@@ -11,6 +11,7 @@
 
 #include "flat_map/tied_sequence.hpp"
 #include "test_case/catch2_tuple.hpp"
+#include "test_case/memory.hpp"
 
 TEST_CASE("zip_iterator", "[iterator]")
 {
@@ -1084,5 +1085,17 @@ TEST_CASE("non contiguous", "[contiguous]")
     SECTION("construct")
     {
         [[maybe_unused]] flat_map::tied_sequence<std::deque<int>, std::deque<int>> ts;
+    }
+}
+
+TEST_CASE("allocator", "[allocator]")
+{
+    SECTION("stateful allocator")
+    {
+        [[maybe_unused]] flat_map::tied_sequence<std::vector<int, stateful_allocator<int>>, std::deque<int, stateful_allocator<int>>> ts
+        {
+            stateful_allocator<int>{"state1"},
+            stateful_allocator<int>{"state2"}
+        };
     }
 }


### PR DESCRIPTION
Forward/copy allocators as `allocator_type` to support container nesting.

closes: #21 